### PR TITLE
make pycodestyle stop checking migrations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 count = False
 max-line-length = 160
 statistics = True
+exclude = migrations


### PR DESCRIPTION
auto-generated migration files should not be checked